### PR TITLE
Add documentation to withPylonNullable on the Future & Stream extension classes in lib/pylon.dart

### DIFF
--- a/lib/pylon.dart
+++ b/lib/pylon.dart
@@ -145,6 +145,13 @@ extension XFuture<T> on Future<T> {
         }
       }).build((t) => Pylon<T>(value: t, builder: builder), loading: loading);
 
+  /// Builds a [FutureBuilder] with parent pylon available for use, allowing nullable values.
+  ///
+  /// Example:
+  /// ```dart
+  /// Future<String?> future = Future.value("Hello World");
+  /// Widget widget = future.withPylonNullable((context) => Text(context.pylon<String?>()));
+  /// ```
   Widget withPylonNullable(BuildContext context,
           Widget Function(BuildContext context) builder) =>
       buildNullable((t) => Pylon<T?>(value: t, builder: builder));
@@ -164,6 +171,13 @@ extension XStream<T> on Stream<T> {
           {Widget? loading}) =>
       build((t) => Pylon<T>(value: t, builder: builder), loading: loading);
 
+  /// Builds a [StreamBuilder] with parent pylon available for use, allowing nullable values.
+  ///
+  /// Example:
+  /// ```dart
+  /// Stream<String?> stream = Stream.value("Hello World");
+  /// Widget widget = stream.withPylonNullable((context) => Text(context.pylon<String?>()));
+  /// ```
   Widget withPylonNullable(BuildContext context,
           Widget Function(BuildContext context) builder) =>
       buildNullable((t) => Pylon<T?>(value: t, builder: builder));


### PR DESCRIPTION
Add documentation for `withPylonNullable` methods in the `Future` and `Stream` extension classes in `lib/pylon.dart`.

* **Future Extension:**
  - Add documentation for `withPylonNullable` method.
  - Describe the purpose and usage of the method.
  - Provide an example of how to use the method.

* **Stream Extension:**
  - Add documentation for `withPylonNullable` method.
  - Describe the purpose and usage of the method.
  - Provide an example of how to use the method.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ArcaneArts/pylon?shareId=bf6a295c-50e2-4354-8724-72d01f7d4a1f).